### PR TITLE
Fix enabling/disabling of search functionality.

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -20,7 +20,11 @@
   <body>
     <redoc
         spec-url='{{ config('redoc.openapi.path') }}'
-        disable-search="{{ config('redoc.config.search') }}"
+        
+        @if (config("redoc.config.search"))
+            disable-search
+        @endif
+
         hide-hostname="{{ config('redoc.config.hostname') }}"
         hide-loading="{{ config('redoc.config.loading') }}"
         menu-toggle="{{ config('redoc.config.menu') }}"


### PR DESCRIPTION
### Problem
With the latest version of redoc 2x alpha it appears that whenever the attribute `disable-search` is added to the redoc tag, regardless of the value it is set to, search is disabled.

### Solution
To fix this, we can conditionally render the `disable-search` attribute only for when it is needed.