### PR TITLE
Feature - Route Middleware

### DIFF
--- a/config/redoc.php
+++ b/config/redoc.php
@@ -12,6 +12,9 @@ return [
     'path' => [
         'name' => env('REDOC_PATH_NAME', 'docs'),
         'url' => env('REDOC_PATH_URL', 'api/docs'),
+        'middleware' => [
+            //\App\Http\Middleware\BasicAuthentication::class,
+        ],
     ],
 
     /*

--- a/routes/redoc.php
+++ b/routes/redoc.php
@@ -7,4 +7,6 @@ Route::view(
     'redoc::docs',
 )->name(
     config('redoc.path.name')
+)->middleware(
+    config('redoc.path.middleware', [])
 );


### PR DESCRIPTION
Problem - Redoc route is public and unprotected

Solution - Optional middleware in route configuration, user can specify which middleware the route is covered by, fallback to empty array if middleware config is missing for backwards compatibility with older configs.